### PR TITLE
SassLint configuration and proxy fix

### DIFF
--- a/gulp/gulp.config.js
+++ b/gulp/gulp.config.js
@@ -27,6 +27,14 @@ function getConfig() {
   config.jshint = {
     jenkinsReport: './target/jshint-checkstyle.xml'
   };
+
+  config.sassLint = {
+    'output-file': 'target/sassLint-checkstyle.xml', // XML output file for sassLint
+    options: {
+    //configFile: 'sassLint-rules.xml',
+      formatter: 'checkstyle'
+    }
+  };
   
   config.packageMode = 'INJECT';
 

--- a/gulp/tasks/analyze/sass.js
+++ b/gulp/tasks/analyze/sass.js
@@ -1,6 +1,8 @@
 var plugins = require('gulp-load-plugins')({lazy: true});
 
 var args = require('yargs').argv;
+var fs = require('fs');
+var extend = require('extend');
 
 var utils = require(global.GULP_DIR + '/utils');
 var config = require(global.CONFIG_PATH || global.GULP_DIR + '/gulp.config');
@@ -16,11 +18,21 @@ module.exports = {
   fn: function (gulp, done) {
     utils.log('***  Performing sass lint analysis ***');
 
+    // read options from configuration
+    var file = null;
+    var opts = {};
+    if(config.sassLint){
+      if(config.sassLint['output-file']){
+        file = fs.createWriteStream(config.sassLint['output-file']);
+      }
+      extend(opts, config.sassLint);
+    }
+
     return gulp
       .src(config.paths[config.style.framework].dev)
       .pipe(plugins.if(!args.exhaustive, plugins.cached('sass-lint')))
-      .pipe(plugins.sassLint())
-      .pipe(plugins.sassLint.format())
+      .pipe(plugins.sassLint(opts))
+      .pipe(plugins.sassLint.format(file))
       .pipe(plugins.sassLint.failOnError());
   }
 };

--- a/package.json
+++ b/package.json
@@ -72,6 +72,8 @@
     "raw-loader": "^0.5.1",
     "webpack": "^1.13.2",
     "yargs": "^4.7.1",
-    "gulp-sass-lint": "^1.2.0"
+    "gulp-sass-lint": "^1.2.0",
+    "tunnel-agent": "^0.4.1",
+    "extend": "^3.0.1"
   }
 }


### PR DESCRIPTION
* Add new dependency 'extend': https://github.com/justmoon/node-extend
* Add 'tunnel-agent' dependency > 0.4.1 to avoid errors using proxies
* Now you can generate a sassLint report using config.sassLint in gulp.config.js file